### PR TITLE
Bugfix - when creating an issue, body was always empty

### DIFF
--- a/creates/issue.js
+++ b/creates/issue.js
@@ -5,7 +5,8 @@ const createIssue = (z, bundle) => {
     method: 'POST',
     url: `https://api.github.com/repos/${bundle.inputData.repo}/issues`,
     body: JSON.stringify({
-      title: bundle.inputData.title
+      title: bundle.inputData.title,
+      body: bundle.inputData.body
     })
   });
   return responsePromise

--- a/test/issue.js
+++ b/test/issue.js
@@ -46,7 +46,8 @@ describe('issue trigger', () => {
     };
     appTester(App.creates.issue.operation.perform, bundle)
       .then((response) => {
-
+        should.exist(response.title);
+        should.exist(response.body);
         done();
       })
       .catch(done);


### PR DESCRIPTION
Hi there,

I found a small issue - when creating a GitHub issue, the body of the issue was always empty. I added body to the issue create and provided a test.