### PR TITLE
Update test script with simplified mocha binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "index.js",
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha --recursive"
+    "test": "mocha --recursive"
   },
   "engines": {
     "node": "8.10.0",


### PR DESCRIPTION
Hello! I just started the tutorial to get going with custom Zapier integration, and I noticed mocha was being hard-referenced. That works fine, but it feels a bit too much. The library itself should "export" the binary instead of consumers hardcoding these references, at least that's my opinion. This way the library can update their internal structure without breaking everything, and [this is done properly by mocha](https://github.com/mochajs/mocha/blob/e825be7c5920a1eb24562c4e027e4997b86f5861/package.json#L456) 😄 

Because this is an example repository, I figured it should use the preferred way of running binaries with `npm-run-script`.

---

#### From [the NPM docs](https://docs.npmjs.com/cli/run-script.html)

In addition to the shell's pre-existing `PATH`, `npm run` adds `node_modules/.bin` to the `PATH` provided to scripts. Any binaries provided by locally-installed dependencies can be used without the `node_modules/.bin` prefix. For example, if there is a `devDependency` on `tap` in your package, you should write:

```
"scripts": {"test": "tap test/\*.js"}
``` 

instead of

```
"scripts": {"test": "node_modules/.bin/tap test/\*.js"}  
```

to run your tests.