### PR TITLE
Bump Node LTS, Zapier to latest, less pinning

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "^10.0"
+    "zapier-platform-core": "10.1.2"
   },
   "devDependencies": {
     "mocha": "^8.0",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "test": "node node_modules/mocha/bin/mocha --recursive"
   },
   "engines": {
-    "node": "8.10.0",
+    "node": "14",
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.0.1"
+    "zapier-platform-core": "^10.0"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "should": "^13.2.0"
+    "mocha": "^8.0",
+    "should": "^13.0"
   }
 }


### PR DESCRIPTION
Hello 👋 

Just cloned this project recently and noticed it asked for Node 8.

Adjusted the following:

* The current Node LTS (Long Term Support) recommended to most users is v14
* Zapier latest major version is 10
* Mocha is on 8
* More flexible pinning for future people that clone this project

Cheers,
Danilo